### PR TITLE
feat: implement MCP tool for updating GitHub issues with plans

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,88 @@
+# Relay MCP Tools
+
+This directory contains MCP (Model Context Protocol) tools that extend Claude Code's capabilities for Relay project management.
+
+## Available Tools
+
+### Issue Planner (`tools/issue-planner`)
+
+Updates GitHub issues with plans extracted from Claude Code conversations.
+
+**Features:**
+- Auto-detects issue number from current git branch (`feature/issue-16` → issue #16)
+- Extracts and formats plan content
+- Updates GitHub issue body with the plan
+- Preserves existing issue content
+
+**Usage:**
+```json
+{
+  "name": "update_issue_plan",
+  "arguments": {
+    "plan": "1. Analyze codebase\n2. Implement feature\n3. Test functionality",
+    "workingDir": "/path/to/project",
+    "issueNumber": 16
+  }
+}
+```
+
+**Parameters:**
+- `plan` (required): The plan content to add to the issue
+- `workingDir` (optional): Working directory, defaults to current directory
+- `issueNumber` (optional): Issue number, auto-detected from branch if not provided
+
+## Setup
+
+1. **Build the tool:**
+   ```bash
+   cd mcp/tools/issue-planner
+   go build -o issue-planner main.go
+   ```
+
+2. **Configure Claude Code:**
+   Add the MCP server configuration to your Claude Code settings:
+   ```json
+   {
+     "mcpServers": {
+       "issue-planner": {
+         "command": "go",
+         "args": ["run", "main.go"],
+         "cwd": "./mcp/tools/issue-planner"
+       }
+     }
+   }
+   ```
+
+3. **Verify GitHub CLI setup:**
+   ```bash
+   gh auth status
+   ```
+
+## Development
+
+### Adding New Tools
+
+1. Create a new directory under `tools/`
+2. Implement the MCP server interface
+3. Add configuration to `mcp_server.json`
+4. Update this README
+
+### Testing
+
+```bash
+# Test issue planner tool
+cd mcp/tools/issue-planner
+echo '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}' | go run main.go
+```
+
+## Architecture
+
+- **`shared/`**: Common utilities shared across MCP tools
+- **`tools/`**: Individual MCP tool implementations
+- **JSON-RPC**: Standard MCP protocol for communication with Claude Code
+
+## Requirements
+
+- Go 1.21+
+- GitHub CLI (`gh`) authenticated
+- Git repository with GitHub remote

--- a/mcp/go.mod
+++ b/mcp/go.mod
@@ -1,0 +1,3 @@
+module github.com/relay/mcp
+
+go 1.21

--- a/mcp/shared/context.go
+++ b/mcp/shared/context.go
@@ -1,0 +1,88 @@
+package shared
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// ExtractIssueNumberFromBranch extracts issue number from branch name
+// Supports patterns like: feature/issue-16, bugfix/issue-42, etc.
+func ExtractIssueNumberFromBranch(branchName string) (int, error) {
+	// Match pattern: any-prefix/issue-{number}
+	re := regexp.MustCompile(`(?i)[\w-]+/issue-(\d+)`)
+	matches := re.FindStringSubmatch(branchName)
+	if len(matches) < 2 {
+		return 0, fmt.Errorf("no issue number found in branch name: %s", branchName)
+	}
+	return strconv.Atoi(matches[1])
+}
+
+// GetCurrentBranch gets the current git branch name
+func GetCurrentBranch(workingDir string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd.Dir = workingDir
+	
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current branch: %w", err)
+	}
+	
+	return strings.TrimSpace(string(output)), nil
+}
+
+// ExtractIssueNumbersFromText extracts issue numbers from text content
+// Supports patterns like: #16, Issue #16, Issue: 16, etc.
+func ExtractIssueNumbersFromText(text string) []int {
+	var numbers []int
+	
+	// Pattern matches: #16, Issue #16, Issue: 16, issue 16, etc.
+	re := regexp.MustCompile(`(?i)(?:#(\d+)|issue[:\s#]+(\d+))`)
+	matches := re.FindAllStringSubmatch(text, -1)
+	
+	for _, match := range matches {
+		for i := 1; i < len(match); i++ {
+			if match[i] != "" {
+				if num, err := strconv.Atoi(match[i]); err == nil {
+					numbers = append(numbers, num)
+				}
+			}
+		}
+	}
+	
+	return numbers
+}
+
+// ExtractPlanFromContext extracts plan content from conversation context
+func ExtractPlanFromContext(context string) string {
+	// Look for plan sections in the context
+	lines := strings.Split(context, "\n")
+	var planLines []string
+	inPlan := false
+	
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		
+		// Start of plan section
+		if strings.Contains(strings.ToLower(line), "plan") && 
+		   (strings.Contains(line, ":") || strings.Contains(line, "for")) {
+			inPlan = true
+			planLines = append(planLines, line)
+			continue
+		}
+		
+		// If we're in a plan section
+		if inPlan {
+			// End of plan section (empty line or new section)
+			if line == "" || 
+			   (strings.HasPrefix(line, "#") && !strings.HasPrefix(line, "##")) {
+				break
+			}
+			planLines = append(planLines, line)
+		}
+	}
+	
+	return strings.Join(planLines, "\n")
+}

--- a/mcp/shared/github.go
+++ b/mcp/shared/github.go
@@ -1,0 +1,183 @@
+package shared
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// GitHubIssue represents a GitHub issue
+type GitHubIssue struct {
+	Number    int        `json:"number"`
+	Title     string     `json:"title"`
+	Body      string     `json:"body"`
+	State     string     `json:"state"`
+	Labels    []string   `json:"labels"`
+	URL       string     `json:"url"`
+	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at"`
+	ClosedAt  *time.Time `json:"closed_at"`
+}
+
+// GitHubService handles GitHub operations via gh CLI
+type GitHubService struct {
+	workingDir string
+	repository string
+}
+
+// NewGitHubService creates a new GitHub service
+func NewGitHubService(workingDir string) (*GitHubService, error) {
+	service := &GitHubService{
+		workingDir: workingDir,
+	}
+	
+	// Auto-detect repository
+	repo, err := service.DetectRepository()
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect repository: %w", err)
+	}
+	service.repository = repo
+	
+	return service, nil
+}
+
+// DetectRepository detects the GitHub repository from git remotes
+func (gs *GitHubService) DetectRepository() (string, error) {
+	cmd := exec.Command("git", "remote", "get-url", "origin")
+	cmd.Dir = gs.workingDir
+
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get git remote: %w", err)
+	}
+
+	remoteURL := strings.TrimSpace(string(output))
+
+	// Parse GitHub repository from various URL formats
+	var repo string
+
+	sshRegex := regexp.MustCompile(`git@github\.com:([^/]+/[^/]+)(?:\.git)?$`)
+	httpsRegex := regexp.MustCompile(`https://github\.com/([^/]+/[^/]+)(?:\.git)?$`)
+
+	if matches := sshRegex.FindStringSubmatch(remoteURL); len(matches) > 1 {
+		repo = matches[1]
+	} else if matches := httpsRegex.FindStringSubmatch(remoteURL); len(matches) > 1 {
+		repo = matches[1]
+	} else {
+		return "", fmt.Errorf("could not parse GitHub repository from remote URL: %s", remoteURL)
+	}
+
+	// Remove .git suffix if present
+	repo = strings.TrimSuffix(repo, ".git")
+
+	return repo, nil
+}
+
+// GetIssue retrieves a GitHub issue by number
+func (gs *GitHubService) GetIssue(number int) (*GitHubIssue, error) {
+	cmd := exec.Command("gh", "issue", "view", strconv.Itoa(number),
+		"--repo", gs.repository,
+		"--json", "number,title,body,state,labels,url,createdAt,updatedAt,closedAt")
+	cmd.Dir = gs.workingDir
+
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch GitHub issue #%d: %w", number, err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(output, &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse GitHub issue JSON: %w", err)
+	}
+
+	issue, err := gs.parseGitHubIssue(raw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse GitHub issue: %w", err)
+	}
+
+	return &issue, nil
+}
+
+// UpdateIssueBody updates the body of a GitHub issue
+func (gs *GitHubService) UpdateIssueBody(number int, newBody string) error {
+	cmd := exec.Command("gh", "issue", "edit", strconv.Itoa(number),
+		"--repo", gs.repository,
+		"--body", newBody)
+	cmd.Dir = gs.workingDir
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to update issue #%d body: %s", number, string(output))
+	}
+
+	return nil
+}
+
+// parseGitHubIssue converts raw JSON data to GitHubIssue struct
+func (gs *GitHubService) parseGitHubIssue(raw map[string]interface{}) (GitHubIssue, error) {
+	issue := GitHubIssue{}
+
+	// Parse number
+	if num, ok := raw["number"].(float64); ok {
+		issue.Number = int(num)
+	} else {
+		return issue, fmt.Errorf("invalid issue number")
+	}
+
+	// Parse title
+	if title, ok := raw["title"].(string); ok {
+		issue.Title = title
+	}
+
+	// Parse body
+	if body, ok := raw["body"].(string); ok {
+		issue.Body = body
+	}
+
+	// Parse state
+	if state, ok := raw["state"].(string); ok {
+		issue.State = strings.ToLower(state)
+	}
+
+	// Parse URL
+	if url, ok := raw["url"].(string); ok {
+		issue.URL = url
+	}
+
+	// Parse labels
+	if labelsRaw, ok := raw["labels"].([]interface{}); ok {
+		for _, labelRaw := range labelsRaw {
+			if labelMap, ok := labelRaw.(map[string]interface{}); ok {
+				if name, ok := labelMap["name"].(string); ok {
+					issue.Labels = append(issue.Labels, name)
+				}
+			}
+		}
+	}
+
+	// Parse timestamps
+	if createdStr, ok := raw["createdAt"].(string); ok {
+		if created, err := time.Parse(time.RFC3339, createdStr); err == nil {
+			issue.CreatedAt = created
+		}
+	}
+
+	if updatedStr, ok := raw["updatedAt"].(string); ok {
+		if updated, err := time.Parse(time.RFC3339, updatedStr); err == nil {
+			issue.UpdatedAt = updated
+		}
+	}
+
+	// Parse closedAt (can be null for open issues)
+	if closedStr, ok := raw["closedAt"].(string); ok && closedStr != "" {
+		if closed, err := time.Parse(time.RFC3339, closedStr); err == nil {
+			issue.ClosedAt = &closed
+		}
+	}
+
+	return issue, nil
+}

--- a/mcp/shared/go.mod
+++ b/mcp/shared/go.mod
@@ -1,0 +1,3 @@
+module shared
+
+go 1.21

--- a/mcp/tools/issue-planner/go.mod
+++ b/mcp/tools/issue-planner/go.mod
@@ -1,0 +1,7 @@
+module issue-planner
+
+go 1.21
+
+replace shared => ../../shared
+
+require shared v0.0.0

--- a/mcp/tools/issue-planner/main.go
+++ b/mcp/tools/issue-planner/main.go
@@ -1,0 +1,307 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"shared"
+)
+
+// MCP Protocol Types
+type MCPRequest struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      interface{} `json:"id"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params,omitempty"`
+}
+
+type MCPResponse struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      interface{} `json:"id"`
+	Result  interface{} `json:"result,omitempty"`
+	Error   *MCPError   `json:"error,omitempty"`
+}
+
+type MCPError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type ToolInfo struct {
+	Name        string                 `json:"name"`
+	Description string                 `json:"description"`
+	InputSchema map[string]interface{} `json:"inputSchema"`
+}
+
+type UpdateIssuePlanParams struct {
+	Plan        string `json:"plan"`
+	WorkingDir  string `json:"workingDir,omitempty"`
+	IssueNumber int    `json:"issueNumber,omitempty"`
+}
+
+type UpdateIssuePlanResult struct {
+	Success     bool   `json:"success"`
+	IssueNumber int    `json:"issueNumber"`
+	Message     string `json:"message"`
+}
+
+func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+	
+	for scanner.Scan() {
+		line := scanner.Text()
+		
+		var request MCPRequest
+		if err := json.Unmarshal([]byte(line), &request); err != nil {
+			sendError(request.ID, -32700, "Parse error")
+			continue
+		}
+		
+		handleRequest(request)
+	}
+}
+
+func handleRequest(request MCPRequest) {
+	switch request.Method {
+	case "initialize":
+		handleInitialize(request)
+	case "tools/list":
+		handleToolsList(request)
+	case "tools/call":
+		handleToolsCall(request)
+	default:
+		sendError(request.ID, -32601, "Method not found")
+	}
+}
+
+func handleInitialize(request MCPRequest) {
+	result := map[string]interface{}{
+		"protocolVersion": "2024-11-05",
+		"capabilities": map[string]interface{}{
+			"tools": map[string]interface{}{},
+		},
+		"serverInfo": map[string]interface{}{
+			"name":    "issue-planner",
+			"version": "1.0.0",
+		},
+	}
+	
+	sendResponse(request.ID, result)
+}
+
+func handleToolsList(request MCPRequest) {
+	tools := []ToolInfo{
+		{
+			Name:        "update_issue_plan",
+			Description: "Updates a GitHub issue with a plan extracted from conversation context",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"plan": map[string]interface{}{
+						"type":        "string",
+						"description": "The plan content to add to the issue",
+					},
+					"workingDir": map[string]interface{}{
+						"type":        "string",
+						"description": "Working directory (optional, defaults to current directory)",
+					},
+					"issueNumber": map[string]interface{}{
+						"type":        "integer",
+						"description": "Issue number (optional, will be auto-detected from branch if not provided)",
+					},
+				},
+				"required": []string{"plan"},
+			},
+		},
+	}
+	
+	result := map[string]interface{}{
+		"tools": tools,
+	}
+	
+	sendResponse(request.ID, result)
+}
+
+func handleToolsCall(request MCPRequest) {
+	paramsMap, ok := request.Params.(map[string]interface{})
+	if !ok {
+		sendError(request.ID, -32602, "Invalid params")
+		return
+	}
+	
+	toolName, ok := paramsMap["name"].(string)
+	if !ok {
+		sendError(request.ID, -32602, "Tool name is required")
+		return
+	}
+	
+	switch toolName {
+	case "update_issue_plan":
+		handleUpdateIssuePlan(request, paramsMap)
+	default:
+		sendError(request.ID, -32601, "Tool not found")
+	}
+}
+
+func handleUpdateIssuePlan(request MCPRequest, paramsMap map[string]interface{}) {
+	// Parse arguments
+	argsMap, ok := paramsMap["arguments"].(map[string]interface{})
+	if !ok {
+		sendError(request.ID, -32602, "Invalid arguments")
+		return
+	}
+	
+	var params UpdateIssuePlanParams
+	
+	// Extract plan (required)
+	if plan, ok := argsMap["plan"].(string); ok {
+		params.Plan = plan
+	} else {
+		sendError(request.ID, -32602, "Plan is required")
+		return
+	}
+	
+	// Extract working directory (optional)
+	if workingDir, ok := argsMap["workingDir"].(string); ok {
+		params.WorkingDir = workingDir
+	} else {
+		// Default to current directory
+		var err error
+		params.WorkingDir, err = os.Getwd()
+		if err != nil {
+			sendError(request.ID, -32603, fmt.Sprintf("Failed to get working directory: %v", err))
+			return
+		}
+	}
+	
+	// Extract issue number (optional)
+	if issueNum, ok := argsMap["issueNumber"].(float64); ok {
+		params.IssueNumber = int(issueNum)
+	}
+	
+	// Execute the tool
+	result, err := updateIssuePlan(params)
+	if err != nil {
+		sendError(request.ID, -32603, err.Error())
+		return
+	}
+	
+	sendResponse(request.ID, result)
+}
+
+func updateIssuePlan(params UpdateIssuePlanParams) (*UpdateIssuePlanResult, error) {
+	// Determine issue number
+	issueNumber := params.IssueNumber
+	
+	if issueNumber == 0 {
+		// Auto-detect from branch
+		branchName, err := shared.GetCurrentBranch(params.WorkingDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get current branch: %w", err)
+		}
+		
+		issueNumber, err = shared.ExtractIssueNumberFromBranch(branchName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to extract issue number from branch '%s': %w", branchName, err)
+		}
+	}
+	
+	// Initialize GitHub service
+	githubService, err := shared.NewGitHubService(params.WorkingDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize GitHub service: %w", err)
+	}
+	
+	// Get current issue
+	issue, err := githubService.GetIssue(issueNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get issue #%d: %w", issueNumber, err)
+	}
+	
+	// Create updated body with plan
+	updatedBody := createUpdatedBody(issue.Body, params.Plan)
+	
+	// Update the issue
+	err = githubService.UpdateIssueBody(issueNumber, updatedBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update issue #%d: %w", issueNumber, err)
+	}
+	
+	return &UpdateIssuePlanResult{
+		Success:     true,
+		IssueNumber: issueNumber,
+		Message:     fmt.Sprintf("Successfully updated issue #%d with plan", issueNumber),
+	}, nil
+}
+
+func createUpdatedBody(existingBody, plan string) string {
+	// If there's no existing body, just add the plan
+	if existingBody == "" {
+		return fmt.Sprintf("## Plan\n\n%s", plan)
+	}
+	
+	// Check if there's already a plan section
+	if strings.Contains(strings.ToLower(existingBody), "## plan") {
+		// Replace existing plan section
+		lines := strings.Split(existingBody, "\n")
+		var newLines []string
+		inPlanSection := false
+		planAdded := false
+		
+		for _, line := range lines {
+			if strings.HasPrefix(strings.ToLower(strings.TrimSpace(line)), "## plan") {
+				inPlanSection = true
+				newLines = append(newLines, "## Plan")
+				newLines = append(newLines, "")
+				newLines = append(newLines, plan)
+				planAdded = true
+				continue
+			}
+			
+			if inPlanSection && strings.HasPrefix(strings.TrimSpace(line), "##") {
+				inPlanSection = false
+			}
+			
+			if !inPlanSection {
+				newLines = append(newLines, line)
+			}
+		}
+		
+		if !planAdded {
+			newLines = append(newLines, "", "## Plan", "", plan)
+		}
+		
+		return strings.Join(newLines, "\n")
+	} else {
+		// Add plan section at the end
+		return fmt.Sprintf("%s\n\n## Plan\n\n%s", existingBody, plan)
+	}
+}
+
+func sendResponse(id interface{}, result interface{}) {
+	response := MCPResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  result,
+	}
+	
+	jsonData, _ := json.Marshal(response)
+	fmt.Println(string(jsonData))
+}
+
+func sendError(id interface{}, code int, message string) {
+	response := MCPResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error: &MCPError{
+			Code:    code,
+			Message: message,
+		},
+	}
+	
+	jsonData, _ := json.Marshal(response)
+	fmt.Println(string(jsonData))
+}

--- a/mcp/tools/issue-planner/mcp_server.json
+++ b/mcp/tools/issue-planner/mcp_server.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "issue-planner": {
+      "command": "go",
+      "args": ["run", "main.go"],
+      "cwd": "./mcp/tools/issue-planner"
+    }
+  }
+}

--- a/mcp/tools/issue-planner/test_request.json
+++ b/mcp/tools/issue-planner/test_request.json
@@ -1,0 +1,1 @@
+{"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {"name": "update_issue_plan", "arguments": {"plan": "## Implementation Plan\n\n1. Create MCP directory structure\n2. Implement issue number extraction\n3. Build GitHub integration\n4. Create MCP server\n5. Test and verify"}}}


### PR DESCRIPTION
## Summary
- Implements MCP tool that updates GitHub issues with plans from Claude Code conversations
- Auto-detects issue numbers from branch names (e.g., `feature/issue-16` → issue #16)
- Provides JSON-RPC interface for Claude Code integration

## Changes Made
- **New MCP directory structure**: `/mcp/tools/issue-planner/`
- **Issue number extraction**: From git branch patterns and conversation context
- **GitHub integration**: Using gh CLI for seamless issue updates
- **MCP server**: Full JSON-RPC protocol implementation
- **Shared utilities**: Reusable components for future MCP tools

## Test Plan
- [x] MCP tool responds to `tools/list` correctly
- [x] Successfully extracts issue number from current branch (`feature/issue-16` → `16`)
- [x] Updates GitHub issue #16 body with plan content
- [x] Preserves existing issue content while adding plan section
- [x] Follows MCP protocol specification for Claude Code discovery

## Files Added
- `mcp/tools/issue-planner/main.go` - MCP server implementation
- `mcp/shared/context.go` - Issue number and plan extraction utilities
- `mcp/shared/github.go` - GitHub API integration helpers
- `mcp/README.md` - Documentation and setup instructions

Resolves #16

🤖 Generated with [Claude Code](https://claude.ai/code)